### PR TITLE
Fix .vimrc for nerdtree buggy :bd

### DIFF
--- a/linux/.vimrc
+++ b/linux/.vimrc
@@ -116,8 +116,8 @@ filetype plugin indent on    "required insert after plugin install
    if exists('g:loaded_webdevicons')
       call webdevicons#refresh()
     endif
-  "close vim if only nerdtree is open
-    autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+  "close vim if only nerdtree is open (comment out. Buggy closes all buffers when :bd)
+    " autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
   "open nerdtree when no file is specified. plain vim, not vim .
   "autocmd StdinReadPre * let s:std_in=1
   "autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif

--- a/macos/.vimrc
+++ b/macos/.vimrc
@@ -116,8 +116,8 @@ filetype plugin indent on    "required insert after plugin install
    if exists('g:loaded_webdevicons')
       call webdevicons#refresh()
     endif
-  "close vim if only nerdtree is open
-    autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
+  "close vim if only nerdtree is open (comment out. Buggy closes all buffers when :bd)
+    " autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
   "open nerdtree when no file is specified. plain vim, not vim .
   "autocmd StdinReadPre * let s:std_in=1
   "autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif


### PR DESCRIPTION
comment out close vim if nerdtree is only window. :bd closes whole vim if files opened via nerdtree. 